### PR TITLE
fix: disable the item whe the client mode is not available

### DIFF
--- a/lib/api/client_provider.dart
+++ b/lib/api/client_provider.dart
@@ -96,4 +96,25 @@ class ClientProvider {
       return {ClientMode.lnlambda};
     }
   }
+
+  /// not all the client are supported in every platform
+  /// due platform limitation (and client API limitation)
+  /// So, this helper method try to semplify the life and
+  /// help to check if a kind of client mode is supported
+  /// or not in the current platform.
+  static bool isClientSupported({required ClientMode mode}) {
+    if (defaultTargetPlatform == TargetPlatform.iOS ||
+        defaultTargetPlatform == TargetPlatform.android) {
+      if (mode != ClientMode.lnlambda) {
+        return false;
+      }
+      return true;
+    } else if (defaultTargetPlatform == TargetPlatform.linux ||
+        defaultTargetPlatform == TargetPlatform.macOS ||
+        defaultTargetPlatform == TargetPlatform.windows) {
+      return true;
+    }
+    // web
+    return mode == ClientMode.lnlambda;
+  }
 }

--- a/lib/views/setting/setting_view.dart
+++ b/lib/views/setting/setting_view.dart
@@ -69,10 +69,11 @@ class _SettingViewState extends State<SettingView> {
               child: DropdownButton(
                 value: setting.clientMode,
                 underline: const SizedBox(),
-                items: clients.map((ClientMode items) {
+                items: clients.map((ClientMode clientMode) {
                   return DropdownMenuItem(
-                    value: items,
-                    child: Text(items.toString()),
+                    enabled: ClientProvider.isClientSupported(mode: clientMode),
+                    value: clientMode,
+                    child: Text(clientMode.toString()),
                   );
                 }).toList(),
                 onChanged: (ClientMode? newValue) {


### PR DESCRIPTION
Avoid to select not supported client inside the client mode, this also avoid confusion when the app will be configured for the first time.

Reported-by: @Shikhar12233456