### PR TITLE
fix: use list pay instead of list invoices modified

### DIFF
--- a/lib/api/api.dart
+++ b/lib/api/api.dart
@@ -4,7 +4,7 @@ import 'package:clnapp/model/app_model/list_invoices.dart';
 import 'package:clnapp/model/app_model/list_transaction.dart';
 import 'package:clnapp/model/app_model/pay_invoice.dart';
 
-import '../model/app_model/list_pays.dart';
+import 'package:clnapp/model/app_model/list_pays.dart';
 
 /// App API implementation, the class contains all the information
 /// to make a call to core lightning and return the correct type
@@ -28,7 +28,7 @@ abstract class AppApi {
   Future<AppListFunds?> listFunds();
 
   /// Return the list of invoices from lightning node.
-  Future<AppListInvoices> listInvoices();
+  Future<AppListInvoices?> listInvoices({required String status});
 
   /// Return the pay response from lightning node.
   Future<AppPayInvoice> payInvoice({required String invoice, int? msat});

--- a/lib/api/api.dart
+++ b/lib/api/api.dart
@@ -28,7 +28,7 @@ abstract class AppApi {
   Future<AppListFunds?> listFunds();
 
   /// Return the list of invoices from lightning node.
-  Future<AppListInvoices?> listInvoices({required String status});
+  Future<AppListInvoices> listInvoices({String? status});
 
   /// Return the pay response from lightning node.
   Future<AppPayInvoice> payInvoice({required String invoice, int? msat});

--- a/lib/api/api.dart
+++ b/lib/api/api.dart
@@ -4,6 +4,8 @@ import 'package:clnapp/model/app_model/list_invoices.dart';
 import 'package:clnapp/model/app_model/list_transaction.dart';
 import 'package:clnapp/model/app_model/pay_invoice.dart';
 
+import '../model/app_model/list_pays.dart';
+
 /// App API implementation, the class contains all the information
 /// to make a call to core lightning and return the correct type
 /// of useful of the UI.
@@ -30,4 +32,7 @@ abstract class AppApi {
 
   /// Return the pay response from lightning node.
   Future<AppPayInvoice> payInvoice({required String invoice, int? msat});
+
+  /// Return the list of payments failed and succeeded
+  Future<AppListPays> listPays();
 }

--- a/lib/api/cln/cln_client.dart
+++ b/lib/api/cln/cln_client.dart
@@ -6,10 +6,12 @@ import 'package:clnapp/api/cln/request/get_info_request.dart';
 import 'package:clnapp/api/cln/request/list_funds_request.dart';
 import 'package:clnapp/api/cln/request/list_invoices_request.dart';
 import 'package:clnapp/api/cln/request/list_transaction_request.dart';
+import 'package:clnapp/api/cln/request/listpays_request.dart';
 import 'package:clnapp/api/cln/request/pay_request.dart';
 import 'package:clnapp/model/app_model/get_info.dart';
 import 'package:clnapp/model/app_model/list_funds.dart';
 import 'package:clnapp/model/app_model/list_invoices.dart';
+import 'package:clnapp/model/app_model/list_pays.dart';
 import 'package:clnapp/model/app_model/list_transaction.dart';
 import 'package:clnapp/model/app_model/pay_invoice.dart';
 import 'package:fixnum/fixnum.dart';
@@ -160,5 +162,27 @@ class CLNApi extends AppApi {
         onDecode: (jsonResponse) => AppPayInvoice.fromJSON(
             jsonResponse as Map<String, dynamic>,
             snackCase: mode == ClientMode.unixSocket));
+  }
+
+  @override
+  Future<AppListPays> listPays() {
+    dynamic params;
+    switch (mode) {
+      case ClientMode.grpc:
+        params = CLNListPaysRequest(grpcRequest: ListpaysRequest());
+        break;
+      case ClientMode.unixSocket:
+        params = CLNListPaysRequest(unixRequest: <String, dynamic>{});
+        break;
+      case ClientMode.lnlambda:
+        params = CLNListPaysRequest(unixRequest: <String, dynamic>{});
+        break;
+    }
+    return client.call<CLNListPaysRequest, AppListPays>(
+        method: "listpays",
+        params: params,
+        onDecode: (jsonResponse) => AppListPays.fromJSON(
+            jsonResponse as Map<String, dynamic>,
+            snackCase: !mode.withCamelCase()));
   }
 }

--- a/lib/api/cln/cln_client.dart
+++ b/lib/api/cln/cln_client.dart
@@ -95,7 +95,7 @@ class CLNApi extends AppApi {
   }
 
   @override
-  Future<AppListInvoices> listInvoices({required String status}) {
+  Future<AppListInvoices> listInvoices({String? status}) {
     dynamic params;
     switch (mode) {
       case ClientMode.grpc:

--- a/lib/api/cln/cln_client.dart
+++ b/lib/api/cln/cln_client.dart
@@ -95,7 +95,7 @@ class CLNApi extends AppApi {
   }
 
   @override
-  Future<AppListInvoices> listInvoices() {
+  Future<AppListInvoices> listInvoices({required String status}) {
     dynamic params;
     switch (mode) {
       case ClientMode.grpc:
@@ -114,7 +114,8 @@ class CLNApi extends AppApi {
         onDecode: (jsonResponse) => AppListInvoices.fromJSON(
             jsonResponse as Map<String, dynamic>,
             snackCase: !mode.withCamelCase(),
-            isObject: mode.hashMsatAsObj()));
+            isObject: mode.hashMsatAsObj(),
+            status: status));
   }
 
   @override

--- a/lib/api/cln/cln_client.dart
+++ b/lib/api/cln/cln_client.dart
@@ -166,16 +166,20 @@ class CLNApi extends AppApi {
 
   @override
   Future<AppListPays> listPays() {
+    /// Defining the map for the pays pays which are completed
+    Map<String, String> map = {"status": "complete"};
     dynamic params;
     switch (mode) {
       case ClientMode.grpc:
-        params = CLNListPaysRequest(grpcRequest: ListpaysRequest());
+        params = CLNListPaysRequest(
+            grpcRequest: ListpaysRequest(
+                status: ListpaysRequest_ListpaysStatus.COMPLETE));
         break;
       case ClientMode.unixSocket:
-        params = CLNListPaysRequest(unixRequest: <String, dynamic>{});
+        params = CLNListPaysRequest(unixRequest: map);
         break;
       case ClientMode.lnlambda:
-        params = CLNListPaysRequest(unixRequest: <String, dynamic>{});
+        params = CLNListPaysRequest(unixRequest: map);
         break;
     }
     return client.call<CLNListPaysRequest, AppListPays>(

--- a/lib/api/cln/request/listpays_request.dart
+++ b/lib/api/cln/request/listpays_request.dart
@@ -1,0 +1,16 @@
+import 'package:cln_grpc/cln_grpc.dart';
+import 'package:clnapp/api/cln/request/cln_request.dart';
+
+class CLNListPaysRequest extends CLNRequest<ListpaysRequest> {
+  CLNListPaysRequest(
+      {Map<String, dynamic>? unixRequest, ListpaysRequest? grpcRequest})
+      : super(unixRequest: unixRequest, grpcRequest: grpcRequest);
+
+  @override
+  Map<String, dynamic> toMap() {
+    if (unixRequest != null) {
+      return unixRequest!;
+    }
+    return grpcRequest!.toProto3Json() as Map<String, dynamic>;
+  }
+}

--- a/lib/model/app_model/list_invoices.dart
+++ b/lib/model/app_model/list_invoices.dart
@@ -2,18 +2,24 @@ import 'package:cln_common/cln_common.dart';
 import 'package:clnapp/model/app_model/app_utils.dart';
 
 class AppListInvoices {
-  List<AppInvoice> invoice;
+  List<AppInvoice?> invoice;
 
   AppListInvoices({this.invoice = const []});
 
   factory AppListInvoices.fromJSON(Map<String, dynamic> json,
-      {bool snackCase = false, bool isObject = false}) {
+      {bool snackCase = false, bool isObject = false, required String status}) {
     var invoices = json.withKey("invoices", snackCase: snackCase) as List;
     if (invoices.isNotEmpty) {
-      var appInvoices = invoices
-          .map((invoice) => AppInvoice.fromJSON(invoice,
-              snackCase: snackCase, isObject: isObject))
-          .toList();
+      var appInvoices = invoices.map((invoice) {
+        var temp = AppInvoice.fromJSON(invoice,
+            snackCase: snackCase, isObject: isObject);
+        if (temp.status == status) {
+          return temp;
+        }
+      }).toList();
+      if (appInvoices.contains(null)) {
+        return AppListInvoices(invoice: []);
+      }
       return AppListInvoices(invoice: appInvoices);
     } else {
       return AppListInvoices();

--- a/lib/model/app_model/list_invoices.dart
+++ b/lib/model/app_model/list_invoices.dart
@@ -13,7 +13,7 @@ class AppListInvoices {
       var appInvoices = invoices.map((invoice) {
         var temp = AppInvoice.fromJSON(invoice,
             snackCase: snackCase, isObject: isObject);
-        if (temp.status == "unpaid") {
+        if (temp.status == status) {
           return temp;
         }
       }).toList();

--- a/lib/model/app_model/list_invoices.dart
+++ b/lib/model/app_model/list_invoices.dart
@@ -7,7 +7,7 @@ class AppListInvoices {
   AppListInvoices({this.invoice = const []});
 
   factory AppListInvoices.fromJSON(Map<String, dynamic> json,
-      {bool snackCase = false, bool isObject = false, required String status}) {
+      {bool snackCase = false, bool isObject = false, String? status}) {
     var invoices = json.withKey("invoices", snackCase: snackCase) as List;
     if (invoices.isNotEmpty) {
       var appInvoices = invoices.map((invoice) {
@@ -18,7 +18,7 @@ class AppListInvoices {
         }
       }).toList();
       if (appInvoices.contains(null)) {
-        return AppListInvoices(invoice: []);
+        return AppListInvoices();
       }
       return AppListInvoices(invoice: appInvoices);
     } else {

--- a/lib/model/app_model/list_invoices.dart
+++ b/lib/model/app_model/list_invoices.dart
@@ -2,7 +2,7 @@ import 'package:cln_common/cln_common.dart';
 import 'package:clnapp/model/app_model/app_utils.dart';
 
 class AppListInvoices {
-  List<AppInvoice?> invoice;
+  List<AppInvoice> invoice;
 
   AppListInvoices({this.invoice = const []});
 
@@ -13,14 +13,14 @@ class AppListInvoices {
       var appInvoices = invoices.map((invoice) {
         var temp = AppInvoice.fromJSON(invoice,
             snackCase: snackCase, isObject: isObject);
-        if (temp.status == status) {
+        if (temp.status == "unpaid") {
           return temp;
         }
       }).toList();
       if (appInvoices.contains(null)) {
         return AppListInvoices();
       }
-      return AppListInvoices(invoice: appInvoices);
+      return AppListInvoices(invoice: appInvoices as List<AppInvoice>);
     } else {
       return AppListInvoices();
     }

--- a/lib/model/app_model/list_pays.dart
+++ b/lib/model/app_model/list_pays.dart
@@ -1,4 +1,3 @@
-import 'package:cln_common/cln_common.dart';
 import 'package:clnapp/model/app_model/app_utils.dart';
 
 class AppListPays {
@@ -9,8 +8,6 @@ class AppListPays {
   factory AppListPays.fromJSON(Map<String, dynamic> json,
       {bool snackCase = false}) {
     var pays = json.withKey("pays", snackCase: snackCase) as List;
-
-    LogManager.getInstance.debug("TRANSACTIONS ARE HERE: !!$pays");
     if (pays.isNotEmpty) {
       var appPays = pays
           .map((pays) => AppPays.fromJSON(pays, snackCase: snackCase))
@@ -25,17 +22,13 @@ class AppListPays {
 class AppPays {
   final String bolt11;
 
-  /// The quantity of Bitcoin in millisatoshi
-  final String amount_sent_msat;
+  final String amountSentMSAT;
 
-  /// If the transaction is confirmed on the blockchain
-  final String createdat;
+  final String createdAt;
 
-  /// If the transaction is reserved for another
   final String status;
 
-  /// flag to identify funds
-  final String paymenthash;
+  final String paymentHash;
 
   final String destination;
 
@@ -43,30 +36,30 @@ class AppPays {
 
   AppPays(
       {required this.bolt11,
-      required this.amount_sent_msat,
-      required this.createdat,
+      required this.amountSentMSAT,
+      required this.createdAt,
       required this.status,
       required this.destination,
-      required this.paymenthash,
+      required this.paymentHash,
       this.identifier = "listpays"});
 
   factory AppPays.fromJSON(Map<String, dynamic> json,
       {bool snackCase = false}) {
     var bolt11 = json.withKey("bolt11", snackCase: snackCase);
-    var amount_sent_msat = json.parseMsat(
+    var amountSentMSAT = json.parseMsat(
         key: "amountsentmsat", snackCase: snackCase, isObject: false);
-    var createdat = json.withKey("created_at", snackCase: snackCase);
+    var createdAt = json.withKey("created_at", snackCase: snackCase);
     var status = json.withKey("status", snackCase: snackCase);
-    var paymenthash = json.withKey("payment_hash", snackCase: snackCase);
+    var paymentHash = json.withKey("payment_hash", snackCase: snackCase);
     var destination = json.withKey("destination", snackCase: snackCase);
 
     /// Checking if the status of the pay is complete or not
     return AppPays(
         bolt11: bolt11,
-        amount_sent_msat: amount_sent_msat,
-        createdat: createdat.toString(),
+        amountSentMSAT: amountSentMSAT,
+        createdAt: createdAt.toString(),
         status: status,
-        paymenthash: paymenthash,
+        paymentHash: paymentHash,
         destination: destination);
   }
 }

--- a/lib/model/app_model/list_pays.dart
+++ b/lib/model/app_model/list_pays.dart
@@ -22,7 +22,7 @@ class AppListPays {
 class AppPays {
   final String bolt11;
 
-  final String amountSentMSAT;
+  final String preimage;
 
   final String createdAt;
 
@@ -36,7 +36,7 @@ class AppPays {
 
   AppPays(
       {required this.bolt11,
-      required this.amountSentMSAT,
+      required this.preimage,
       required this.createdAt,
       required this.status,
       required this.destination,
@@ -46,8 +46,8 @@ class AppPays {
   factory AppPays.fromJSON(Map<String, dynamic> json,
       {bool snackCase = false}) {
     var bolt11 = json.withKey("bolt11", snackCase: snackCase);
-    var amountSentMSAT = json.parseMsat(
-        key: "amountsentmsat", snackCase: snackCase, isObject: false);
+    var preimage =
+        json.parseMsat(key: "preimage", snackCase: snackCase, isObject: false);
     var createdAt = json.withKey("created_at", snackCase: snackCase);
     var status = json.withKey("status", snackCase: snackCase);
     var paymentHash = json.withKey("payment_hash", snackCase: snackCase);
@@ -55,11 +55,11 @@ class AppPays {
 
     /// Checking if the status of the pay is complete or not
     return AppPays(
-        bolt11: bolt11,
-        amountSentMSAT: amountSentMSAT,
+        bolt11: bolt11 ?? "No bolt11 for this transaction",
+        preimage: preimage,
         createdAt: createdAt.toString(),
         status: status,
         paymentHash: paymentHash,
-        destination: destination);
+        destination: destination ?? "No destination");
   }
 }

--- a/lib/model/app_model/list_pays.dart
+++ b/lib/model/app_model/list_pays.dart
@@ -1,0 +1,72 @@
+import 'package:cln_common/cln_common.dart';
+import 'package:clnapp/model/app_model/app_utils.dart';
+
+class AppListPays {
+  List<AppPays> pays;
+
+  AppListPays({this.pays = const []});
+
+  factory AppListPays.fromJSON(Map<String, dynamic> json,
+      {bool snackCase = false}) {
+    var pays = json.withKey("pays", snackCase: snackCase) as List;
+
+    LogManager.getInstance.debug("TRANSACTIONS ARE HERE: !!$pays");
+    if (pays.isNotEmpty) {
+      var appPays = pays
+          .map((pays) => AppPays.fromJSON(pays, snackCase: snackCase))
+          .toList();
+      return AppListPays(pays: appPays);
+    } else {
+      return AppListPays();
+    }
+  }
+}
+
+class AppPays {
+  final String bolt11;
+
+  /// The quantity of Bitcoin in millisatoshi
+  final String amount_sent_msat;
+
+  /// If the transaction is confirmed on the blockchain
+  final String createdat;
+
+  /// If the transaction is reserved for another
+  final String status;
+
+  /// flag to identify funds
+  final String paymenthash;
+
+  final String destination;
+
+  final String identifier;
+
+  AppPays(
+      {required this.bolt11,
+      required this.amount_sent_msat,
+      required this.createdat,
+      required this.status,
+      required this.destination,
+      required this.paymenthash,
+      this.identifier = "listpays"});
+
+  factory AppPays.fromJSON(Map<String, dynamic> json,
+      {bool snackCase = false}) {
+    var bolt11 = json.withKey("bolt11", snackCase: snackCase);
+    var amount_sent_msat = json.parseMsat(
+        key: "amountsentmsat", snackCase: snackCase, isObject: false);
+    var createdat = json.withKey("created_at", snackCase: snackCase);
+    var status = json.withKey("status", snackCase: snackCase);
+    var paymenthash = json.withKey("payment_hash", snackCase: snackCase);
+    var destination = json.withKey("destination", snackCase: snackCase);
+
+    /// Checking if the status of the pay is complete or not
+    return AppPays(
+        bolt11: bolt11,
+        amount_sent_msat: amount_sent_msat,
+        createdat: createdat.toString(),
+        status: status,
+        paymenthash: paymenthash,
+        destination: destination);
+  }
+}

--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -119,9 +119,8 @@ class _HomeViewState extends State<HomeView> {
 
     List list = [];
 
-    if (invoicesList != null) {
-      list.addAll(invoicesList.invoice);
-    }
+    list.addAll(invoicesList.invoice);
+
     list.addAll(paysList.pays);
 
     /// FIXME: sort the payments list

--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -146,7 +146,7 @@ class _HomeViewState extends State<HomeView> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text("Bolt11: ${items[index].bolt11}"),
-              Text("amount sent msat: ${items[index].amountSentMSAT}"),
+              Text("preimage : ${items[index].preimage}"),
               Text("Created At: ${items[index].createdAt}"),
               Text("status: ${items[index].status}"),
               Text("payment Hash: ${items[index].paymentHash}"),

--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -113,12 +113,15 @@ class _HomeViewState extends State<HomeView> {
   }
 
   Future<List<dynamic>?> listPayments() async {
-    final invoicesList = await widget.provider.get<AppApi>().listInvoices();
+    final invoicesList =
+        await widget.provider.get<AppApi>().listInvoices(status: "paid");
     final paysList = await widget.provider.get<AppApi>().listPays();
 
     List list = [];
 
-    list.addAll(invoicesList.invoice);
+    if (invoicesList != null) {
+      list.addAll(invoicesList.invoice);
+    }
     list.addAll(paysList.pays);
 
     /// FIXME: sort the payments list
@@ -164,14 +167,6 @@ class _HomeViewState extends State<HomeView> {
                 shrinkWrap: true,
                 itemCount: snapshot.data!.length,
                 itemBuilder: (context, index) {
-                  /// Returning a null widget when the invoice is unpaid
-                  if (snapshot.data![index].identifier == "invoice" &&
-                      snapshot.data![index].status == "unpaid") {
-                    return const SizedBox(
-                      width: 0,
-                      height: 0,
-                    );
-                  }
                   return ExpandableCard(
                     expandedAlignment: Alignment.topLeft,
                     expandableChild: _buildSpecificPaymentView(

--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -114,12 +114,20 @@ class _HomeViewState extends State<HomeView> {
 
   Future<List<dynamic>?> listPayments() async {
     final invoicesList = await widget.provider.get<AppApi>().listInvoices();
-    final fundsList = await widget.provider.get<AppApi>().listFunds();
+    // final fundsList = await widget.provider.get<AppApi>().listFunds();
+    final paysList = await widget.provider.get<AppApi>().listPays();
 
-    var listPayments = List.from(invoicesList.invoice)..addAll(fundsList!.fund);
+    List list = [];
+
+    list.addAll(invoicesList.invoice);
+    list.addAll(paysList.pays);
+
+    LogManager.getInstance.debug("FINAL PAYLIST PAYS !!!!: ${paysList.pays}");
+
+    // var listPayments = List.from(invoicesList.invoice)..addAll(fundsList!.fund);
 
     /// FIXME: sort the payments list
-    return listPayments;
+    return list;
   }
 
   Widget _buildSpecificPaymentView(
@@ -140,9 +148,12 @@ class _HomeViewState extends State<HomeView> {
         : Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text("Amount: ${items[index].amount}"),
-              Text("Confirmed: ${items[index].confirmed}"),
-              Text("Reversed: ${items[index].reserved}"),
+              Text("Amount: ${items[index].bolt11}"),
+              Text("amount sent msat: ${items[index].amount_sent_msat}"),
+              Text("Created At: ${items[index].createdat}"),
+              Text("status: ${items[index].status}"),
+              Text("payment Hash: ${items[index].paymenthash}"),
+              Text("Destination: ${items[index].destination}"),
             ],
           );
   }
@@ -184,7 +195,9 @@ class _HomeViewState extends State<HomeView> {
                               child: Text(
                                 snapshot.data![index].identifier == "invoice"
                                     ? snapshot.data![index].label
-                                    : snapshot.data![index].txId,
+                                    : snapshot.data![index].status == "complete"
+                                        ? snapshot.data![index].bolt11
+                                        : "Transaction failed",
                                 overflow: TextOverflow.ellipsis,
                                 style: const TextStyle(
                                   fontSize: 15,

--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -114,17 +114,12 @@ class _HomeViewState extends State<HomeView> {
 
   Future<List<dynamic>?> listPayments() async {
     final invoicesList = await widget.provider.get<AppApi>().listInvoices();
-    // final fundsList = await widget.provider.get<AppApi>().listFunds();
     final paysList = await widget.provider.get<AppApi>().listPays();
 
     List list = [];
 
     list.addAll(invoicesList.invoice);
     list.addAll(paysList.pays);
-
-    LogManager.getInstance.debug("FINAL PAYLIST PAYS !!!!: ${paysList.pays}");
-
-    // var listPayments = List.from(invoicesList.invoice)..addAll(fundsList!.fund);
 
     /// FIXME: sort the payments list
     return list;
@@ -148,11 +143,11 @@ class _HomeViewState extends State<HomeView> {
         : Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text("Amount: ${items[index].bolt11}"),
-              Text("amount sent msat: ${items[index].amount_sent_msat}"),
-              Text("Created At: ${items[index].createdat}"),
+              Text("Bolt11: ${items[index].bolt11}"),
+              Text("amount sent msat: ${items[index].amountSentMSAT}"),
+              Text("Created At: ${items[index].createdAt}"),
               Text("status: ${items[index].status}"),
-              Text("payment Hash: ${items[index].paymenthash}"),
+              Text("payment Hash: ${items[index].paymentHash}"),
               Text("Destination: ${items[index].destination}"),
             ],
           );
@@ -169,6 +164,14 @@ class _HomeViewState extends State<HomeView> {
                 shrinkWrap: true,
                 itemCount: snapshot.data!.length,
                 itemBuilder: (context, index) {
+                  /// Returning a null widget when the invoice is unpaid
+                  if (snapshot.data![index].identifier == "invoice" &&
+                      snapshot.data![index].status == "unpaid") {
+                    return const SizedBox(
+                      width: 0,
+                      height: 0,
+                    );
+                  }
                   return ExpandableCard(
                     expandedAlignment: Alignment.topLeft,
                     expandableChild: _buildSpecificPaymentView(
@@ -195,9 +198,7 @@ class _HomeViewState extends State<HomeView> {
                               child: Text(
                                 snapshot.data![index].identifier == "invoice"
                                     ? snapshot.data![index].label
-                                    : snapshot.data![index].status == "complete"
-                                        ? snapshot.data![index].bolt11
-                                        : "Transaction failed",
+                                    : snapshot.data![index].bolt11,
                                 overflow: TextOverflow.ellipsis,
                                 style: const TextStyle(
                                   fontSize: 15,

--- a/test/unix_client_appapi_test.dart
+++ b/test/unix_client_appapi_test.dart
@@ -44,7 +44,7 @@ void main() async {
       final invoiceList =
           await provider.get<AppApi>().listInvoices(status: "paid");
       expect(invoiceList, isNotNull);
-      expect(invoiceList!.invoice, isNotNull);
+      expect(invoiceList.invoice, isNotNull);
     });
 
     test('API List Transactions', () async {

--- a/test/unix_client_appapi_test.dart
+++ b/test/unix_client_appapi_test.dart
@@ -41,9 +41,10 @@ void main() async {
     });
 
     test('API List Invoices', () async {
-      final invoiceList = await provider.get<AppApi>().listInvoices();
+      final invoiceList =
+          await provider.get<AppApi>().listInvoices(status: "paid");
       expect(invoiceList, isNotNull);
-      expect(invoiceList.invoice, isNotNull);
+      expect(invoiceList!.invoice, isNotNull);
     });
 
     test('API List Transactions', () async {


### PR DESCRIPTION
For now the screen shows all the transaction that are completed or failed following the command :

`lightning-cli listpays --testnet`


![Screenshot from 2023-03-09 23-44-35](https://user-images.githubusercontent.com/90508384/224118324-fc968d1d-b668-48f7-ae30-b4f81187e9e5.png)



fix #28 