### PR TITLE
null value fix

### DIFF
--- a/lib/model/app_model/pay_invoice.dart
+++ b/lib/model/app_model/pay_invoice.dart
@@ -16,4 +16,5 @@ class AppPayInvoice {
       return AppPayInvoice(payResponse: json);
     }
   }
+  Map<String, dynamic> toJson() => payResponse;
 }

--- a/lib/views/pay/pay_view.dart
+++ b/lib/views/pay/pay_view.dart
@@ -4,6 +4,8 @@ import 'package:clnapp/model/app_model/pay_invoice.dart';
 import 'package:clnapp/utils/app_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:cln_common/cln_common.dart';
+import 'dart:convert' ; 
 
 class PayView extends StatefulWidget {
   final AppProvider provider;
@@ -98,10 +100,10 @@ class _PayViewState extends State<PayView> {
                       });
                 }
               }),
-          paymentResponse != null
+          paymentResponse != null && paymentResponse!.payResponse != null 
               ? paymentResponse!.payResponse["Error"] == null
                   ? Text(
-                      "Payment Successfully : ${paymentResponse!.payResponse["amountMsat"]["msat"]} msats")
+                      "Payment Successful : ${paymentResponse!.payResponse["amount_msat"]} ")
                   : Text("${paymentResponse!.payResponse["Error"]}")
               : Container(),
         ],


### PR DESCRIPTION
the pay_view.dart is trying to access " ["amountMsat"]["msat" ]" for the paymentResponse generated assuming the response to be : 
"payResponse": 
{
    "amountMsat": 
     {
      "msat": 10000000
     }
}

But the actual response is this : 
{ 
payment_preimage: a81a90093a42bd816135170b20ee80213d1e6be180fdfb475d39eeb8ee731fab,
status: complete,
msatoshi: 1000,
amount_msat: 1000msat,
msatoshi_sent: 1000,
amount_sent_msat: 1000msat,
destination: 02049b60c296ffead3e7c8b124c5730153403a8314c1116c2d1b43cf9ac0de2d9d,
payment_hash: 082605051b8ece0cc1fcf4faec86da4cf672f9da1aa68c839d7bd3465040125c,
created_at: 1679055835,
parts: 1
}

replacing the " ["amountMsat"]["msat" ] " with ["amount_msat"] 

fixes #80 