### PR TITLE
fix: SocketException on macOS v13.x

### DIFF
--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<true/>
+	<false/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.client</key>


### PR DESCRIPTION
Fixes the SocketException which occurred on macOS Ventura when ran in debug/profile mode