### PR TITLE
fix : fixes the web crash of the application

### DIFF
--- a/lib/views/pay/pay_view.dart
+++ b/lib/views/pay/pay_view.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:cln_common/cln_common.dart';
 import 'package:clnapp/api/api.dart';
 import 'package:clnapp/components/bottomsheet.dart';
@@ -11,6 +9,7 @@ import 'package:clnapp/views/pay/numberpad_view.dart';
 import 'package:clnapp/views/pay/scanner_view.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:trash_component/utils/platform_utils.dart';
 
 class PayView extends StatefulWidget {
   final AppProvider provider;
@@ -141,7 +140,7 @@ class _PayViewState extends State<PayView> {
       appBar: AppBar(
         elevation: 0,
         actions: [
-          Platform.isAndroid || Platform.isIOS
+          PlatformUtils.isMobile
               ? Padding(
                   padding: const EdgeInsets.only(right: 8),
                   child: IconButton(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,10 @@ dependencies:
   cln_grpc: ^0.0.1-beta.3
   cln_common: ^0.0.1-beta.1
   clightning_rpc: ^0.0.2-beta.4
-  trash_component: ^0.0.3
+  trash_component:
+    git:
+      url: https://github.com/vincenzopalazzo/trash
+      path: packages/components
   get_it: ^7.2.0
   bottom_navy_bar: ^6.0.0
   trash_themes: ^0.0.3


### PR DESCRIPTION
## Why do we need this :
Was unable to launch the application on the web.

## Changes made : 
Added `trash_component` dependency to check the environment of the application, and showing appbar(error causing component) only on mobile devices.