### PR TITLE
fix: CI failing due to Flutter Analyse issues

### DIFF
--- a/lib/components/bottomsheet.dart
+++ b/lib/components/bottomsheet.dart
@@ -57,7 +57,7 @@ class CLNBottomSheet {
                       },
                       child: Text(
                         '$display msats',
-                        textScaleFactor: 1.0,
+                        textScaler: const TextScaler.linear(1.0),
                         style: TextStyle(
                           fontSize: 40,
                           fontWeight: FontWeight.bold,

--- a/lib/views/pay/numberpad_view.dart
+++ b/lib/views/pay/numberpad_view.dart
@@ -32,7 +32,9 @@ class _NumberPadState extends State<NumberPad> {
           .payInvoice(invoice: boltString, msat: amountMsat);
       transactionView(response.payResponse.paymentHash);
     } on LNClientException catch (e) {
-      PopUp.showPopUp(context, 'Failed to pay the invoice', e.message, true);
+      if (mounted) {
+        PopUp.showPopUp(context, 'Failed to pay the invoice', e.message, true);
+      }
     }
   }
 
@@ -43,8 +45,14 @@ class _NumberPadState extends State<NumberPad> {
           .withdraw(destination: destination, mSatoshi: amount);
       transactionView(response.txId);
     } on LNClientException catch (e) {
-      PopUp.showPopUp(
-          context, 'Failed to pay to the given address', e.message, true);
+      if (mounted) {
+        PopUp.showPopUp(
+          context,
+          'Failed to pay to the given address',
+          e.message,
+          true,
+        );
+      }
     }
   }
 

--- a/lib/views/pay/pay_view.dart
+++ b/lib/views/pay/pay_view.dart
@@ -37,7 +37,9 @@ class _PayViewState extends State<PayView> {
             context, 'Payment Successful', 'Payment successfully sent', false);
       }
     } on LNClientException catch (e) {
-      PopUp.showPopUp(context, 'Invalid Rune', e.message, true);
+      if (mounted) {
+        PopUp.showPopUp(context, 'Invalid Rune', e.message, true);
+      }
     }
   }
 

--- a/lib/views/request/request_view.dart
+++ b/lib/views/request/request_view.dart
@@ -39,7 +39,9 @@ class _RequestViewState extends State<RequestView> {
       });
       return true;
     } on LNClientException catch (e) {
-      PopUp.showPopUp(context, 'Invalid Rune', e.message, true);
+      if (mounted) {
+        PopUp.showPopUp(context, 'Invalid Rune', e.message, true);
+      }
       return false;
     }
   }
@@ -57,7 +59,9 @@ class _RequestViewState extends State<RequestView> {
       });
       return true;
     } on LNClientException catch (e) {
-      PopUp.showPopUp(context, 'Invalid Rune', e.message, true);
+      if (mounted) {
+        PopUp.showPopUp(context, 'Invalid Rune', e.message, true);
+      }
       return false;
     }
   }
@@ -70,7 +74,9 @@ class _RequestViewState extends State<RequestView> {
       });
       return true;
     } on LNClientException catch (e) {
-      PopUp.showPopUp(context, 'Invalid Rune', e.message, true);
+      if (mounted) {
+        PopUp.showPopUp(context, 'Invalid Rune', e.message, true);
+      }
       return false;
     }
   }

--- a/lib/views/request/request_view.dart
+++ b/lib/views/request/request_view.dart
@@ -363,7 +363,7 @@ class _RequestViewState extends State<RequestView> {
                 )
               : Text(
                   value,
-                  textScaleFactor: 1.0,
+                  textScaler: const TextScaler.linear(1.0),
                   style: const TextStyle(
                     fontSize: 35,
                     fontWeight: FontWeight.bold,


### PR DESCRIPTION
The CI was failing because of the following issues:
```
info • 'textScaleFactor' is deprecated and shouldn't be used. Use textScaler instead. Use of textScaleFactor was deprecated in preparation for the upcoming nonlinear text scaling support. This feature was deprecated after v3.12.0-2.0.pre • lib/components/bottomsheet.dart:60:25 • deprecated_member_use
info • Don't use 'BuildContext's across async gaps • lib/views/pay/numberpad_view.dart:35:7 • use_build_context_synchronously
info • Don't use 'BuildContext's across async gaps • lib/views/pay/numberpad_view.dart:46:7 • use_build_context_synchronously
info • Don't use 'BuildContext's across async gaps • lib/views/pay/pay_view.dart:40:7 • use_build_context_synchronously
info • Don't use 'BuildContext's across async gaps • lib/views/request/request_view.dart:42:7 • use_build_context_synchronously
info • Don't use 'BuildContext's across async gaps • lib/views/request/request_view.dart:60:7 • use_build_context_synchronously
info • Don't use 'BuildContext's across async gaps • lib/views/request/request_view.dart:73:7 • use_build_context_synchronously
info • 'textScaleFactor' is deprecated and shouldn't be used. Use textScaler instead. Use of textScaleFactor was deprecated in preparation for the upcoming nonlinear text scaling support. This feature was deprecated after v3.12.0-2.0.pre • lib/views/request/request_view.dart:360:[19](https://github.com/dart-lightning/lndart.clnapp/actions/runs/7798729177/job/21268017041?pr=139#step:7:20) • deprecated_member_use
```
This PR fixes the issues by

- Checking if the current widget is mounted with the help of the `mounted` property provided by Stateful Widget
```
if(mounted){
// Mounted will be true if the widget hasn't been removed from the widget tree.
// code here
}
```
- Replacing the deprecated textScaleFactor with textScaler
```
Previously:
textScaleFactor: 1.0

Now:
textScaler: TextScaler.linear(1.0)
```