### PR TITLE
feat: Make lnlambda.lnmetrics.info default lamdaServer url

### DIFF
--- a/lib/components/bottomsheet.dart
+++ b/lib/components/bottomsheet.dart
@@ -57,7 +57,6 @@ class CLNBottomSheet {
                       },
                       child: Text(
                         '$display msats',
-                        textScaler: const TextScaler.linear(1.0),
                         style: TextStyle(
                           fontSize: 40,
                           fontWeight: FontWeight.bold,

--- a/lib/components/bottomsheet.dart
+++ b/lib/components/bottomsheet.dart
@@ -57,7 +57,7 @@ class CLNBottomSheet {
                       },
                       child: Text(
                         '$display msats',
-                        textScaleFactor: 1.0,
+                        textScaler: const TextScaler.linear(1.0),
                         style: TextStyle(
                           fontSize: 40,
                           fontWeight: FontWeight.bold,

--- a/lib/model/user_setting.dart
+++ b/lib/model/user_setting.dart
@@ -9,6 +9,7 @@ class Setting {
   String? host;
   String? path;
   String? nodeId;
+  bool? customLambdaServer;
   String? lambdaServer;
   String? rune;
 
@@ -17,7 +18,8 @@ class Setting {
       this.host,
       this.path,
       this.nodeId,
-      this.lambdaServer = "https://lnlambda.lnmetrics.info",
+      this.customLambdaServer,
+      this.lambdaServer,
       this.rune}) {
     clientMode = ClientProvider.getClientByDefPlatform().first;
   }
@@ -56,6 +58,7 @@ class Setting {
             'nodeId': nodeId,
             'host': host,
             'rune': rune,
+            'customLambdaServer': customLambdaServer,
             'lambdaServer': lambdaServer,
           };
         }
@@ -73,6 +76,7 @@ class Setting {
         return path != null;
       case ClientMode.lnlambda:
         return nodeId != null &&
+            customLambdaServer != null &&
             lambdaServer != null &&
             rune != null &&
             host != null;

--- a/lib/model/user_setting.dart
+++ b/lib/model/user_setting.dart
@@ -17,7 +17,7 @@ class Setting {
       this.host,
       this.path,
       this.nodeId,
-      this.lambdaServer,
+      this.lambdaServer = "https://lnlambda.lnmetrics.info",
       this.rune}) {
     clientMode = ClientProvider.getClientByDefPlatform().first;
   }

--- a/lib/model/user_setting.dart
+++ b/lib/model/user_setting.dart
@@ -18,8 +18,8 @@ class Setting {
       this.host,
       this.path,
       this.nodeId,
-      this.customLambdaServer,
-      this.lambdaServer,
+      this.customLambdaServer = false,
+      this.lambdaServer = "https://lnlambda.lnmetrics.info",
       this.rune}) {
     clientMode = ClientProvider.getClientByDefPlatform().first;
   }

--- a/lib/model/user_setting.g.dart
+++ b/lib/model/user_setting.g.dart
@@ -11,6 +11,7 @@ Setting _$SettingFromJson(Map<String, dynamic> json) => Setting(
       host: json['host'] as String?,
       path: json['path'] as String?,
       nodeId: json['nodeId'] as String?,
+      customLambdaServer: json['customLambdaServer'] as bool?,
       lambdaServer: json['lambdaServer'] as String?,
       rune: json['rune'] as String?,
     );
@@ -28,6 +29,7 @@ Map<String, dynamic> _$SettingToJson(Setting instance) {
   writeNotNull('host', instance.host);
   writeNotNull('path', instance.path);
   writeNotNull('nodeId', instance.nodeId);
+  writeNotNull('customLambdaServer', instance.customLambdaServer);
   writeNotNull('lambdaServer', instance.lambdaServer);
   writeNotNull('rune', instance.rune);
   return val;

--- a/lib/views/pay/pay_view.dart
+++ b/lib/views/pay/pay_view.dart
@@ -32,7 +32,7 @@ class _PayViewState extends State<PayView> {
   Future<void> payInvoice(String boltString) async {
     try {
       await widget.provider.get<AppApi>().payInvoice(invoice: boltString);
-      if (context.mounted) {
+      if (mounted) {
         PopUp.showPopUp(
             context, 'Payment Successful', 'Payment successfully sent', false);
       }

--- a/lib/views/request/request_view.dart
+++ b/lib/views/request/request_view.dart
@@ -363,7 +363,7 @@ class _RequestViewState extends State<RequestView> {
                 )
               : Text(
                   value,
-                  textScaleFactor: 1.0,
+                  textScaler: const TextScaler.linear(1.0),
                   style: const TextStyle(
                     fontSize: 35,
                     fontWeight: FontWeight.bold,

--- a/lib/views/setting/lnlambda_setting_view.dart
+++ b/lib/views/setting/lnlambda_setting_view.dart
@@ -41,11 +41,8 @@ class _LnlambdaSettingViewState extends State<LnlambdaSettingView> {
           ),
           const Text("Lambda Server"),
           DropdownButtonFormField(
-            value: setting.customLambdaServer == null
-                ? null
-                : setting.customLambdaServer == true
-                    ? 'custom'
-                    : setting.lambdaServer,
+            value:
+                setting.customLambdaServer! ? 'custom' : setting.lambdaServer,
             items: const [
               DropdownMenuItem(
                 value: 'https://lnlambda.lnmetrics.info',

--- a/lib/views/setting/lnlambda_setting_view.dart
+++ b/lib/views/setting/lnlambda_setting_view.dart
@@ -40,16 +40,48 @@ class _LnlambdaSettingViewState extends State<LnlambdaSettingView> {
             ),
           ),
           const Text("Lambda Server"),
-          TextFormField(
-            controller: TextEditingController(text: setting.lambdaServer),
-            onChanged: (text) {
-              setting.lambdaServer = text;
+          DropdownButtonFormField(
+            value: setting.customLambdaServer == null
+                ? null
+                : setting.customLambdaServer == true
+                    ? 'custom'
+                    : setting.lambdaServer,
+            items: const [
+              DropdownMenuItem(
+                value: 'https://lnlambda.lnmetrics.info',
+                child: Text("https://lnlambda.lnmetrics.info"),
+              ),
+              DropdownMenuItem(
+                value: 'custom',
+                child: Text("Enter lambda server url manually"),
+              ),
+            ],
+            onChanged: (value) {
+              setState(() {
+                if (value == 'custom') {
+                  setting.customLambdaServer = true;
+                } else {
+                  setting.customLambdaServer = false;
+                  setting.lambdaServer = value as String;
+                }
+              });
             },
-            decoration: const InputDecoration(
-              label: Text("lnlambda server url"),
-              border: OutlineInputBorder(),
-            ),
           ),
+          () {
+            if (setting.customLambdaServer == true) {
+              return TextFormField(
+                controller: TextEditingController(text: setting.lambdaServer),
+                onChanged: (text) {
+                  setting.lambdaServer = text;
+                },
+                decoration: const InputDecoration(
+                  label: Text("lnlambda server url"),
+                  border: OutlineInputBorder(),
+                ),
+              );
+            }
+            return const SizedBox();
+          }(),
           const Text("Rune"),
           TextFormField(
             controller: TextEditingController(text: setting.rune ?? ''),

--- a/lib/views/setting/lnlambda_setting_view.dart
+++ b/lib/views/setting/lnlambda_setting_view.dart
@@ -41,7 +41,7 @@ class _LnlambdaSettingViewState extends State<LnlambdaSettingView> {
           ),
           const Text("Lambda Server"),
           TextFormField(
-            controller: TextEditingController(text: setting.lambdaServer ?? ''),
+            controller: TextEditingController(text: setting.lambdaServer),
             onChanged: (text) {
               setting.lambdaServer = text;
             },

--- a/lib/views/setting/setting_view.dart
+++ b/lib/views/setting/setting_view.dart
@@ -91,18 +91,19 @@ class _SettingViewState extends State<SettingView> {
                 children: [
                   ElevatedButton(
                     onPressed: () async {
-                      if (setting.isValid()) {
+                      if (setting.isValid() && context.mounted) {
                         await saveSettings(setting: setting);
                         await ManagerAPIProvider.registerClientFromSetting(
                             setting, widget.provider);
                         // https://stackoverflow.com/questions/68871880/do-not-use-buildcontexts-across-async-gaps
-                        if (!mounted) return;
-                        Navigator.of(context).pushAndRemoveUntil(
-                            MaterialPageRoute(
-                                builder: (context) => HomeView(
-                                      provider: widget.provider,
-                                    )),
-                            (Route<dynamic> route) => false);
+                        if (context.mounted) {
+                          Navigator.of(context).pushAndRemoveUntil(
+                              MaterialPageRoute(
+                                  builder: (context) => HomeView(
+                                        provider: widget.provider,
+                                      )),
+                              (Route<dynamic> route) => false);
+                        }
                       } else {
                         PopUp.showPopUp(
                             context,


### PR DESCRIPTION
While setting up connection type of `ClientMode.lnlambda`, the user has to provide a URL for a lambda server. Those who aren't aware of any, they can use `lnlambda.lnmetrics.info`, but this thing isn't documented anywhere. Hence this PR makes `https://lnlambda.lnmetrics.info` the default option for lambda server which the user can change if they want to.

<img width="488" alt="CLN App Web Screenshot" src="https://github.com/dart-lightning/lndart.clnapp/assets/59914433/3129740f-484b-41e3-b29a-a9fa99f7d2b9">
